### PR TITLE
🔧Make DasEmployerConfig available to all IConfiguration DI consumers

### DIFF
--- a/src/SFA.DAS.IdentifyDataLocks.Web/Program.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using SFA.DAS.Configuration.AzureTableStorage;
+using System.Reflection;
 
 namespace SFA.DAS.IdentifyDataLocks.Web
 {
@@ -12,6 +14,18 @@ namespace SFA.DAS.IdentifyDataLocks.Web
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configBuilder =>
+                {
+                    var config = configBuilder.Build();
+                    var assemblyName = Assembly.GetAssembly(typeof(Startup)).GetName().Name;
+                    configBuilder.AddAzureTableStorage(options =>
+                     {
+                         options.ConfigurationKeys = new[] { assemblyName };
+                         options.StorageConnectionString = config["ConfigurationStorageConnectionString"];
+                         options.EnvironmentName = config["EnvironmentName"];
+                         options.PreFixConfigurationKeys = false;
+                     });
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Startup.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Startup.cs
@@ -11,8 +11,6 @@ using SFA.DAS.EAS.Account.Api.Client;
 using SFA.DAS.IdentifyDataLocks.Web.Infrastructure;
 using SFA.DAS.Payments.Application.Repositories;
 using SFA.DAS.Providers.Api.Client;
-using SFA.DAS.Configuration.AzureTableStorage;
-using System.Reflection;
 
 namespace SFA.DAS.IdentifyDataLocks.Web
 {
@@ -20,20 +18,8 @@ namespace SFA.DAS.IdentifyDataLocks.Web
     {
         public IConfiguration Configuration { get; }
 
-        public Startup(IConfiguration configuration)
-        {
-            var assemblyName =  Assembly.GetAssembly(typeof(Startup)).GetName().Name;
-            Configuration = new ConfigurationBuilder()
-                .AddConfiguration(configuration)
-                .AddAzureTableStorage(options =>
-                    {
-                        options.ConfigurationKeys = new[] { assemblyName };
-                        options.StorageConnectionString = configuration["ConfigurationStorageConnectionString"];
-                        options.EnvironmentName = configuration["EnvironmentName"];
-                        options.PreFixConfigurationKeys = false;
-                    })
-                .Build();
-        }
+        public Startup(IConfiguration configuration) =>
+            Configuration = configuration;
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
The CDN wasn't being used to load the GDS files.

Specifically, `CdnTagHelpers` uses `IConfiguration` to find the CDN base URL.  This can be stored in DasEmployerConfiguration only if the ASP.Net Core App configuration is able to read from Azure table storage.