### PR TITLE
FAI-857 DataLocks Store Auth Session token in Redis

### DIFF
--- a/src/SFA.DAS.IdentifyDataLocks.Web/Infrastructure/CustomServiceRole.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Infrastructure/CustomServiceRole.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using SFA.DAS.DfESignIn.Auth.Enums;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
 using SFA.DAS.IdentifyDataLocks.Web.Constants;
 
@@ -16,5 +17,6 @@ namespace SFA.DAS.IdentifyDataLocks.Web.Infrastructure
             _authorizationConfiguration = configuration.GetSection(ConfigKey.Authorization).Get<AuthorizationConfiguration>();
         }
         public string RoleClaimType => _authorizationConfiguration.ClaimId;
+        public CustomServiceRoleValueType RoleValueType => CustomServiceRoleValueType.Name;
     }
 }

--- a/src/SFA.DAS.IdentifyDataLocks.Web/SFA.DAS.IdentifyDataLocks.Web.csproj
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/SFA.DAS.IdentifyDataLocks.Web.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.45" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.51" />
     <PackageReference Include="SFA.DAS.Http" Version="3.2.65" />
     <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.6.3100" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="8.19.18" />

--- a/src/SFA.DAS.IdentifyDataLocks.Web/ServiceExtension.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/ServiceExtension.cs
@@ -13,6 +13,7 @@ namespace SFA.DAS.IdentifyDataLocks.Web
     public static class ServiceExtension
     {
         private const string ClientName = "DataLocks";
+        private const string SignedOutCallBackPath = "/SignedOut";
 
         public static IServiceCollection AddAuthentication(this IServiceCollection services, IConfiguration config)
         {
@@ -21,7 +22,7 @@ namespace SFA.DAS.IdentifyDataLocks.Web
             if (useDfESignIn)
             {
                 // register DfeSignIn authentication services to the AspNetCore Authentication Options.
-                services.AddAndConfigureDfESignInAuthentication(config, CookieName.AuthCookie, typeof(CustomServiceRole), ClientName);
+                services.AddAndConfigureDfESignInAuthentication(config, CookieName.AuthCookie, typeof(CustomServiceRole), ClientName, SignedOutCallBackPath);
             }
             else
             {


### PR DESCRIPTION
Commit Details
Updated the DfESignIn Nuget Package with latest
Redis to store the Auth Session Token

Story Link: https://skillsfundingagency.atlassian.net/browse/FAI-857