### PR TITLE
FAI-941 Create access denied page for Identify Data Locks Service

### DIFF
--- a/src/SFA.DAS.IdentifyDataLocks.UnitTests/Web/Error/WhenAccessDeniedOnGet.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.UnitTests/Web/Error/WhenAccessDeniedOnGet.cs
@@ -1,0 +1,39 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.IdentifyDataLocks.Web.Constants;
+using SFA.DAS.IdentifyDataLocks.Web.Pages;
+
+namespace SFA.DAS.IdentifyDataLocks.UnitTests.Web.Error
+{
+    public class WhenAccessDeniedOnGet
+    {
+        [TestCase("test", "https://test-services.signin.education.gov.uk/approvals/select-organisation?action=request-service", true)]
+        [TestCase("pp", "https://test-services.signin.education.gov.uk/approvals/select-organisation?action=request-service", true)]
+        [TestCase("local", "https://test-services.signin.education.gov.uk/approvals/select-organisation?action=request-service", false)]
+        [TestCase("prd", "https://services.signin.education.gov.uk/approvals/select-organisation?action=request-service", false)]
+        [TestCase("", "https://services.signin.education.gov.uk/approvals/select-organisation?action=request-service", false)]
+        public void Then_Return_SamePropertyValue(string env, string helpLink, bool useDfESignIn)
+        {
+            //arrange
+            var mockConfiguration = new Mock<IConfiguration>();
+            var mockDfESignInSection = new Mock<IConfigurationSection>();
+            var mockResourceEnvSection = new Mock<IConfigurationSection>();
+
+            mockDfESignInSection.Setup(a => a.Value).Returns(useDfESignIn.ToString());
+            mockResourceEnvSection.Setup(a => a.Value).Returns(env);
+
+            mockConfiguration.Setup(a => a.GetSection(ConfigKey.ResourceEnvironmentName)).Returns(mockResourceEnvSection.Object);
+            mockConfiguration.Setup(a => a.GetSection(ConfigKey.UseDfESignIn)).Returns(mockDfESignInSection.Object);
+
+            //sut
+            var model = new AccessDenied(mockConfiguration.Object);
+            model.OnGet();
+
+            //assert
+            model.UseDfESignIn.Should().Be(useDfESignIn);
+            model.HelpPageLink.Should().Be(helpLink);
+        }
+    }
+}

--- a/src/SFA.DAS.IdentifyDataLocks.UnitTests/Web/Index/WhenIndexOnGet.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.UnitTests/Web/Index/WhenIndexOnGet.cs
@@ -1,20 +1,40 @@
 ﻿using AutoFixture.NUnit3;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.IdentifyDataLocks.Web.Constants;
 using SFA.DAS.IdentifyDataLocks.Web.Pages;
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
 
 namespace SFA.DAS.IdentifyDataLocks.UnitTests.Web.Index
 {
     public class WhenIndexOnGet
     {
         [Test, AutoData]
-        public void Then_Return_SamePropertyValue(bool useDfESignIn)
+        public void Then_User_Not_Authenticated_Return_Page(bool useDfESignIn)
         {
             //arrange
+            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext(new DefaultHttpContext()
+            {
+                User = null
+            }, new RouteData(), new PageActionDescriptor(), modelState);
+            var modelMetadataProvider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
+            var pageContext = new PageContext(actionContext)
+            {
+                ViewData = viewData
+            };
+
             var logger = new Mock<ILogger<IndexModel>>();
             var configuration = new Mock<IConfiguration>();
             var configurationSection = new Mock<IConfigurationSection>();
@@ -22,12 +42,47 @@ namespace SFA.DAS.IdentifyDataLocks.UnitTests.Web.Index
             configuration.Setup(a => a.GetSection(ConfigKey.UseDfESignIn)).Returns(configurationSection.Object);
 
             //sut
-            var model = new IndexModel(logger.Object, configuration.Object);
+            var model = new IndexModel(logger.Object, configuration.Object)
+            {
+                PageContext = pageContext
+            };
             model.OnGet();
 
             //assert
             var actual = model.UseDfESignIn;
             actual.Should().Be(useDfESignIn);
+        }
+
+        [Test, AutoData]
+        public void Then_User_Authenticated_Return_Redirect()
+        {
+            //arrange
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new GenericIdentity("displayName"))
+            };
+            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor(), modelState);
+            var modelMetadataProvider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
+            var pageContext = new PageContext(actionContext)
+            {
+                ViewData = viewData
+            };
+
+            var logger = new Mock<ILogger<IndexModel>>();
+            var configuration = new Mock<IConfiguration>();
+
+            //sut
+            var model = new IndexModel(logger.Object, configuration.Object)
+            {
+                PageContext = pageContext
+            };
+            var actual = model.OnGet() as RedirectToPageResult;
+
+            //assert
+            actual.Should().NotBeNull();
+            actual?.PageName.Should().Be("Start");
         }
     }
 }

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Constants/ConfigKey.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Constants/ConfigKey.cs
@@ -5,5 +5,6 @@
         public const string UseDfESignIn = "UseDfESignIn";
         public const string Authorization = "Authorization";
         public const string Authentication = "Authentication";
+        public const string ResourceEnvironmentName = "ResourceEnvironmentName";
     }
 }

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <header class="page-header group">
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Access denied</h1>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">You aren't approved to view this page</h1>
         </header>
         <div class="article-container">
             <article role="article" class="group">

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml
@@ -1,6 +1,7 @@
 @page
+@model AccessDenied
 @{
-    ViewBag.Title = "Access denied";
+    ViewBag.Title = "You aren't approved – Apprenticeship service identify data locks";
     ViewBag.ShowNav = false;
 }
 <div class="govuk-grid-row">
@@ -11,10 +12,29 @@
         <div class="article-container">
             <article role="article" class="group">
                 <div class="inner">
-                    <p class="govuk-body">This page is not available to you. If you need access to this page, please ask your team leader</p>
-                    <p>
-                        <a asp-page="signedout" class="govuk-button">Sign out</a>
+                    <p class="govuk-body">
+                        To view this page, you need:
                     </p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>approval to use this service</li>
+                        <li>the correct service role to access this page</li>
+                    </ul>
+                    @if (Model.UseDfESignIn)
+                    {
+                        <p class="govuk-body">
+                            You can <a href="@Model.HelpPageLink" target="_blank" rel="noopener noreferrer">request access to this service in your DfE Sign-in.</a> You can also use this link to request a higher service role.
+                        </p>
+                        <p class="govuk-body">
+                            The DfE Sign-in approver inside your organisation will need to approve your request.
+                        </p>
+                    }
+                    else
+                    {
+                        <p class="govuk-body">This page is not available to you. If you need access to this page, please ask your team leader</p>
+                        <p>
+                            <a href="/signout" class="govuk-button">Sign out</a>
+                        </p>
+                    }
                 </div>
             </article>
         </div>

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml
@@ -1,7 +1,7 @@
 @page
 @model AccessDenied
 @{
-    ViewBag.Title = "You aren't approved – Apprenticeship service identify data locks";
+    ViewBag.Title = "You aren't approved - Apprenticeship service identify data locks";
     ViewBag.ShowNav = false;
 }
 <div class="govuk-grid-row">

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/AccessDenied.cshtml.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.IdentifyDataLocks.Web.Constants;
+using System;
+
+namespace SFA.DAS.IdentifyDataLocks.Web.Pages
+{
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public class AccessDenied : PageModel
+    {
+        private readonly IConfiguration _configuration;
+        private string _integrationUrlPart = string.Empty;
+        private string _environment = string.Empty;
+
+        public bool UseDfESignIn { get; set; }
+
+        public AccessDenied(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public void OnGet()
+        {
+            UseDfESignIn = _configuration.GetValue<bool>(ConfigKey.UseDfESignIn);
+            _environment = _configuration.GetValue<string>(ConfigKey.ResourceEnvironmentName);
+        }
+        
+
+        /// <summary>
+        /// Gets DfESignIn Select service link.
+        /// </summary>
+        public string HelpPageLink
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_environment) && !_environment.Equals("prd", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    _integrationUrlPart = "test-";
+                }
+                return $"https://{_integrationUrlPart}services.signin.education.gov.uk/approvals/select-organisation?action=request-service";
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/Index.cshtml.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/Index.cshtml.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.IdentifyDataLocks.Web.Pages
     {
         private readonly ILogger<IndexModel> _logger;
         private readonly IConfiguration _configuration;
-        
+
         public bool UseDfESignIn { get; set; }
 
         public IndexModel(ILogger<IndexModel> logger, IConfiguration configuration)
@@ -19,9 +19,13 @@ namespace SFA.DAS.IdentifyDataLocks.Web.Pages
             _configuration = configuration;
         }
 
-        public void OnGet()
+        public IActionResult OnGet()
         {
+            if (User.Identity is { IsAuthenticated: true }) { return RedirectToPage("Start"); }
+
             UseDfESignIn = _configuration.GetValue<bool>(ConfigKey.UseDfESignIn);
+
+            return Page();
         }
     }
 }

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/Learner.cshtml.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/Learner.cshtml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SFA.DAS.IdentifyDataLocks.Domain;
@@ -9,6 +10,7 @@ using SFA.DAS.IdentifyDataLocks.Web.Infrastructure;
 
 namespace SFA.DAS.IdentifyDataLocks.Web.Pages
 {
+    [Authorize(Policy = AuthorizationConfiguration.PolicyName)]
     public class LearnerModel : PageModel
     {
         [BindProperty(SupportsGet = true)]

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/LearnerDetails.cshtml.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/LearnerDetails.cshtml.cs
@@ -9,6 +9,7 @@ using SFA.DAS.Payments.Model.Core.Entities;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 
 namespace SFA.DAS.IdentifyDataLocks.Web.Pages
 {
@@ -17,6 +18,7 @@ namespace SFA.DAS.IdentifyDataLocks.Web.Pages
         public string Identifier { get; set; }
     }
 
+    [Authorize(Policy = AuthorizationConfiguration.PolicyName)]
     public class LearnerDetailsModel : PageModel
     {
         [BindProperty(SupportsGet = true)]

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/PaymentsLearner.cshtml.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/PaymentsLearner.cshtml.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 
 namespace SFA.DAS.IdentifyDataLocks.Web.Pages
 {
+    [Authorize(Policy = AuthorizationConfiguration.PolicyName)]
     public class PaymentsLearnerModel : PageModel
     {
         [BindProperty(SupportsGet = true)]

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Pages/Start.cshtml.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Pages/Start.cshtml.cs
@@ -1,9 +1,11 @@
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace SFA.DAS.IdentifyDataLocks.Web.Pages
 {
+    [Authorize(Policy = AuthorizationConfiguration.PolicyName)]
     public class StartModel : PageModel
     {
         [BindProperty]

--- a/src/SFA.DAS.IdentifyDataLocks.Web/SFA.DAS.IdentifyDataLocks.Web.csproj
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/SFA.DAS.IdentifyDataLocks.Web.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.63" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.65" />
     <PackageReference Include="SFA.DAS.Http" Version="3.2.65" />
     <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.6.3100" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="8.19.18" />

--- a/src/SFA.DAS.IdentifyDataLocks.Web/Startup.cs
+++ b/src/SFA.DAS.IdentifyDataLocks.Web/Startup.cs
@@ -53,9 +53,11 @@ namespace SFA.DAS.IdentifyDataLocks.Web
                     .AllowAnonymousToPage("/index");
                 //This redirection is required as IDAMs is configured to return to this path for localhost.
                 options.Conventions.AddPageRoute("/accessdenied", "account/accessdenied");
+                //This redirection is required as DfESignIn is configured to return to this path for localhost.
+                options.Conventions.AddPageRoute("/accessdenied", "error/403");
             });
             var authorizationConfig = Configuration.GetSection(ConfigKey.Authorization).Get<AuthorizationConfiguration>();
-            
+
             services.AddAuthentication(Configuration);
             services.AddAuthorization(authorizationConfig);
             services.AddDataProtection(Configuration, Environment);


### PR DESCRIPTION
Commit Details:
1. Amended Access Denied Page for DfESignIn Users.
2. Unit Testing included with the test coverage for newly added code.
3. DfESignIn Auth PKG upgraded to the Latest v17.1.56

Story: https://skillsfundingagency.atlassian.net/browse/FAI-941